### PR TITLE
Updated log-monitor-es's resource allocations and team name

### DIFF
--- a/launch/log-monitor-es.yml
+++ b/launch/log-monitor-es.yml
@@ -5,8 +5,9 @@ env:
 - SIGNALFX_API_KEY
 - MONITOR_NAME
 resources:
-  cpu: 0.05
-  max_mem: 0.05
+  cpu: 0.01
+  max_mem: 0.01
 shepherds:
-  - ryan.burns@clever.com
-  - xavi.ramirez@clever.com
+- ryan.burns@clever.com
+- xavi.ramirez@clever.com
+team: eng-infra


### PR DESCRIPTION
Updated resource allocations based on metrics from the past week.

Memory across both services and workers was adjusted to accommodate the max usage seen.  Additional head room was given to apps that hit their max-memory.

CPU for services and workers was adjusted differently from one another.  For workers, CPU allocation was set to a value between the 90<sup>th</sup> and 100<sup>th</sup> percentile.  CPU for services, on the other hand, was set to be slightly above their max usage.

The data these changes were based is linked below.  Please take a look to confirm the new values: https://docs.google.com/spreadsheets/d/14ReGEtZz5oCKaQ6frCqtSH_yW8nBsHRO07miJZDjTTo/edit#gid=0

Finally the team name was added to the launch yaml.

This PR was created programmatically and assigned randomly.  Feel free to reassign.

Context:
- https://clever.atlassian.net/browse/INFRA-1699
- https://clever.atlassian.net/browse/INFRA-1711
