### PR TITLE
only search for heartbeats from the past 5 minutes

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,9 +47,13 @@ func getLatestTimestamps(esClient *elastic.Client) (map[string]time.Time, error)
 	timestamp := elastic.NewMaxAggregation().Field("Timestamp")
 	hostname = hostname.SubAggregation("latestTimes", timestamp)
 
+	q := elastic.NewBoolQuery()
+	q = q.Must(elastic.NewTermQuery("Title", "heartbeat"))
+	q = q.Must(elastic.NewRangeQuery("Timestamp").Gte("now-5m/m").Lte("now/m"))
+
 	searchResult, err := esClient.Search().
 		Index(elasticsearchIndex).
-		Query(elastic.NewTermQuery("Title", "heartbeat")).
+		Query(q).
 		SearchType("count").
 		Aggregation("hosts", hostname).
 		Pretty(true).


### PR DESCRIPTION
Previously, if a machine went offline, this query would still write its
last timestamp to SignalFX. Instead, we should stop writing new
datapoints if there isn't new data. We can use SignalFX's extrapolicy
policy if necessary.

Example of what happened before when some machines were turned offline.
The flat lines represent when a machine stopped sending new Heartbeat
timestamps.

![image](https://cloud.githubusercontent.com/assets/102242/18973674/99bb30f4-8653-11e6-9841-fb86d5e214a2.png)

Output before:

``` json
{"count":34,"level":"info","source":"log-monitor-es","title":"timestamp"}
```

Output after:

``` json
{"count":13,"level":"info","source":"log-monitor-es","title":"timestamp"}
```
