### PR TITLE
Lowered log-monitor-es's cpu allocation to 0

### DIFF
--- a/launch/log-monitor-es.yml
+++ b/launch/log-monitor-es.yml
@@ -8,8 +8,8 @@ env:
 - METRIC_NAME
 - COMPONENT_NAME
 resources:
-  cpu: 0.01
-  max_mem: 0.02
+  cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
+  max_mem: 0.25
 shepherds:
 - ryan.burns@clever.com
 - xavi.ramirez@clever.com


### PR DESCRIPTION
## This an automated PR

*Risk rating*: :moneybag::moneybag::money_with_wings:

Worst case scenario, jobs are a bit slower and fail slightly more often.  The vast majority of our
cluster's CPU is unutilized, so it's unlikely this worker will get CPU starved.

## Details:

By their nature, workers are asynchronous, which means most of the time they're not doing much and
when they are doing something, it's not super important that they do it quickly.

**But with 0 CPU, how will my worker compute anything?**

CPU is a funny thing.  It flows like water to the process that's most in need.  If your container
needs more CPU and the host machine has more CPU to give, your container will get more CPU.  That's
why it's okay to set a container's CPU to 0.  The [CPU value](https://github.com/Clever/catapult/blob/65acdd4214a9a878aaf4369670d508cfe940b4dd/launch/catapult.yml#L33)
declared in launch yaml acts more like a CPU minimum.  In the case of Catapult, it's guaranteed to
have access to at least 0.1 CPU core at all times.

Context:
- https://clever.atlassian.net/browse/INFRA-2120
