### PR TITLE
set timestamp to now for instances that aren't running anymore

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,7 +178,7 @@ func main() {
 			continue
 		}
 
-		// remove data for instances that aren't running
+		// correct the data for instances that aren't running
 		for hostname := range timestamps {
 			if strings.HasPrefix(hostname, "ip-") {
 				// parse IP address out of ES hostnames of the form ip-10-0-0-1
@@ -187,7 +187,8 @@ func main() {
 				if err != nil {
 					kvlog.ErrorD("ec2-ip-check", kv.M{"error": err.Error()})
 				} else if !running {
-					delete(timestamps, hostname)
+					// set to now so that signalfx's last datapoint is ok
+					timestamps[hostname] = time.Now()
 				}
 			}
 		}


### PR DESCRIPTION
The logic to remove timestamps for instances no longer running sometimes takes longer than 120 seconds to kick in. This means that it will trigger the signalfx detector, since the last datapoint for these hosts will exceed our alerting thresholds (see https://clever.slack.com/archives/C08G6CNMN/p1504712423000196). Instead of deleting these timestamps, this PR sets them to `time.Now()` so that signalfx gets datapoints within a normal range for these hosts.