### PR TITLE
fix some problems with metric reporting

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func getLatestTimestamps(esClient *elastic.Client) (map[string]time.Time, error)
 
 	q := elastic.NewBoolQuery()
 	q = q.Must(elastic.NewTermQuery("title", "heartbeat"))
-	q = q.Must(elastic.NewRangeQuery("timestamp").Gte("now-5m/m").Lte("now/m"))
+	q = q.Must(elastic.NewRangeQuery("timestamp").Gte("now-1h").Lte("now"))
 
 	searchResult, err := esClient.Search().
 		Index(elasticsearchIndex).
@@ -170,8 +170,7 @@ func main() {
 	ec2api := ec2.New(sess)
 	ec2ip := &ec2IPChecker{ec2api: ec2api}
 
-	tick := time.Tick(15 * time.Second)
-	for {
+	for c := time.Tick(15 * time.Second); ; <-c {
 		timestamps, err := getLatestTimestamps(esClient)
 		if err != nil {
 			kvlog.ErrorD("timestamp", kv.M{"error": err.Error()})
@@ -204,7 +203,5 @@ func main() {
 			continue
 		}
 		kvlog.Info("sent-to-signalfx")
-
-		<-tick
 	}
 }


### PR DESCRIPTION
log-monitor-es doesn't always report data correctly

https://www.dropbox.com/s/zcjx8gyd9uciiq7/Screenshot%202017-12-04%2013.17.52.png?dl=0 <- notice no data being reported to signalfx

https://www.dropbox.com/s/k2d3ynfz799avh0/Screenshot%202017-12-04%2013.18.26.png?dl=0 <- notice count:0, i.e. no data being reported

why it happens:

log-monitor-es searches elasticsearch limiting to the last 5 minutes (see "now-5m" in the code), so if we fall further than 5 minutes behind, no data is returned and no metric is sent to signalfx

solution in this PR:
- search further back
- also fixes a problem with how the for loop tick was being ignored in
error cases which I think is the cause of
https://clever.atlassian.net/browse/INFRA-2677