### PR TITLE
Improve reporting consistency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -101,9 +101,10 @@
   revision = "e02fc20de94c78484cd5ffb007f8af96be030a45"
 
 [[projects]]
+  branch = "master"
   name = "github.com/xeipuuv/gojsonschema"
   packages = ["."]
-  revision = "0c8571ac0ce161a5feb57375a9cdf148c98c0f70"
+  revision = "ac52e6811b56ee2b7730a88915e956afe2cc0d69"
 
 [[projects]]
   name = "golang.org/x/net"
@@ -117,8 +118,8 @@
     "logger",
     "router"
   ]
-  revision = "e6f953eac5b9d8e41dff6587e0ae6d58b50da5c5"
-  version = "v6.7.3"
+  revision = "c8c3a96b8862f1b962ba9febf5afd2a1c3789fe0"
+  version = "v6.15.0"
 
 [[projects]]
   name = "gopkg.in/logfmt.v0"
@@ -151,6 +152,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1cbbc13d1c72e32145081c0d7edc645ea8af85c5da2a296e2569b30473c53c15"
+  inputs-digest = "ae663b6a8a1aceed44d555940406686bd617f9e9b03dd1cc7224a871eac2d229"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "gopkg.in/Clever/kayvee-go.v6"
-  version = "6.7.3"
+  version = "^6.15.0"
 
 [[constraint]]
   name = "gopkg.in/olivere/elastic.v5"

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 func getLatestTimestamps(esClient *elastic.Client) (map[string]time.Time, error) {
-	hostname := elastic.NewTermsAggregation().Field("hostname").Size(200)
+	hostname := elastic.NewTermsAggregation().Field("hostname").Size(500)
 	timestamp := elastic.NewMaxAggregation().Field("timestamp")
 	hostname = hostname.SubAggregation("latestTimes", timestamp)
 

--- a/main.go
+++ b/main.go
@@ -193,15 +193,13 @@ func main() {
 		}
 
 		// Log the number of hosts reported
-		kvlog.InfoD("timestamp", kv.M{
-			"count": len(timestamps),
-		})
+		kvlog.DebugD("timestamp", kv.M{"count": len(timestamps)})
 
 		err = sendToSignalFX(timestamps)
 		if err != nil {
 			kvlog.ErrorD("send-to-signalfx", kv.M{"error": err.Error()})
 			continue
 		}
-		kvlog.Info("sent-to-signalfx")
+		kvlog.Trace("sent-to-signalfx")
 	}
 }


### PR DESCRIPTION
The [logging pipeline delay alert](https://app.signalfx.com/#/detector/v1/CZwxzLWAgC8/edit) has become increasing noisy.  Often times that the log delay for an ec2 instances goes from 0 mins to over 30 mins less in than a 5 mins timespan, which doesn't make sense.  This leads me to believe there is something wrong with the reporting.

According to [stackoverflow](https://stackoverflow.com/questions/35526893), ES aggregations are not always accurate.  It also suggests to improve accuracy, the `shard_size` of the aggregations needs to be increased, which can be done two ways: increase the size of the aggregation or manually set the `shard_size` value.  I opted to increase the aggregation size since it'll also ensures that all ec2 instances are returned.  We're often running more than 200 machines.