### PR TITLE
Increased shard-size to reduced flakiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+bin
+log-monitor-es
+
 # Created by https://www.gitignore.io
 
 ### Go ###

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -1,0 +1,10 @@
+routes:
+  search-error:
+    matchers:
+      title: [ "failed-search" ]
+    output:
+      type: "notifications"
+      channel: "#alerts-staging-infra"
+      icon: ":elasticsearch:"
+      message: "Failed elastic search query.  Is kibana down?\n>%{error}"
+      user: "log-monitor-es"

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func getLatestTimestamps(esClient *elastic.Client) (map[string]time.Time, error)
 		SearchType("count").
 		Aggregation("hosts", hostname).
 		Pretty(true).
-		Timeout("15s").
+		Timeout("30s").
 		Do(context.TODO())
 
 	if err != nil {
@@ -171,7 +171,7 @@ func main() {
 	ec2api := ec2.New(sess)
 	ec2ip := &ec2IPChecker{ec2api: ec2api}
 
-	for c := time.Tick(15 * time.Second); ; <-c {
+	for c := time.Tick(30 * time.Second); ; <-c {
 		timestamps, err := getLatestTimestamps(esClient)
 		if err != nil {
 			kvlog.ErrorD("timestamp", kv.M{"error": err.Error()})

--- a/main.go
+++ b/main.go
@@ -103,7 +103,8 @@ func sendToSignalFX(timestamps map[string]time.Time) error {
 		}
 
 		datum := sfxclient.Gauge(metricName, dimensions, timestamp.Unix())
-		datumLag := sfxclient.GaugeF(fmt.Sprintf("%s-lag", metricName), dimensions, float64(now.Sub(timestamp))/float64(time.Second))
+		delta := now.Sub(timestamp).Seconds()
+		datumLag := sfxclient.GaugeF(fmt.Sprintf("%s-lag", metricName), dimensions, delta)
 		points = append(points, datum, datumLag)
 	}
 

--- a/main.go
+++ b/main.go
@@ -50,7 +50,8 @@ func init() {
 func getLatestTimestamps(esClient *elastic.Client) (map[string]time.Time, error) {
 	hostname := elastic.NewTermsAggregation().Field("hostname").Size(500)
 	timestamp := elastic.NewMaxAggregation().Field("timestamp")
-	hostname = hostname.SubAggregation("latestTimes", timestamp)
+	// Increasing ShardSize should increase accuracy:
+	hostname = hostname.SubAggregation("latestTimes", timestamp).ShardSize(1500)
 
 	q := elastic.NewBoolQuery()
 	q = q.Must(elastic.NewTermQuery("title", "heartbeat"))


### PR DESCRIPTION
A follow up on https://github.com/Clever/log-monitor-es/pull/29

To improve accuracy of (and improve flakiness of end-to-end alerting), the shard-size was increased to 1500.  Also 503 errors are sent to #oncall-infra.  Several 503's suggest that kibana is inaccessible.