### PR TITLE
INFRA-3317 -- Send error alerts to #oncall-infra

### DIFF
--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -4,7 +4,7 @@ routes:
       title: [ "failed-search" ]
     output:
       type: "notifications"
-      channel: "#alerts-staging-infra"
+      channel: "#oncall-infra"
       icon: ":elasticsearch:"
       message: "Failed elastic search query.  Is kibana down?\n>%{error}"
       user: "log-monitor-es"


### PR DESCRIPTION
To increase the visibility of possible kibana outages, send error messages to oncall-infra.

Related: https://clever.atlassian.net/browse/INFRA-3317