### PR TITLE
Removed unneeded "Install awscli for ECR publish" command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,6 @@ jobs:
         name: Set up CircleCI artifacts directories
     - run: make install_deps
     - run: make build
-    - run: $HOME/ci-scripts/circleci/report-card $RC_DOCKER_USER $RC_DOCKER_PASS "$RC_DOCKER_EMAIL" $RC_GITHUB_TOKEN
-    - run:
-        command: |-
-          cd /tmp/ && wget https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
-          sudo apt-get update
-          sudo apt-get install python-dev
-          sudo pip install --upgrade awscli && aws --version
-          pip install --upgrade --user awscli
-        name: Install awscli for ECR publish
     - run: $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
     - run: $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS log-monitor-es
     - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS log-monitor-es dev-infra no-confirm-deploy; fi;


### PR DESCRIPTION
## This an automated PR
*Risk rating*: low :cat:

Individual circle-ci commands now install the awscli automatically.

Also removed deprecated report-card commands.

Context:
- https://clever.atlassian.net/browse/INFRA-3343
